### PR TITLE
Workflow templates for BICAN McCarroll CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,9 @@
 # of maintenance through personnel turnover.
 /.github/workflow-templates/bits-example.yml             @broadinstitute/devnull
 /.github/workflow-templates/bits-example.properties.json @broadinstitute/devnull
+/.github/workflow-templates/bican-mccarroll-r-package.yml @broadinstitute/bican-mccarroll-admin
+/.github/workflow-templates/bican-mccarroll-r-package.properties.json @broadinstitute/bican-mccarroll-admin
+/.github/workflow-templates/bican-mccarroll-python-package.yml @broadinstitute/bican-mccarroll-admin
+/.github/workflow-templates/bican-mccarroll-python-package.properties.json @broadinstitute/bican-mccarroll-admin
+/.github/workflow-templates/bican-mccarroll-roxygen.yml @broadinstitute/bican-mccarroll-admin
+/.github/workflow-templates/bican-mccarroll-roxygen.properties.json @broadinstitute/bican-mccarroll-admin

--- a/.github/workflow-templates/bican-mccarroll-python-package.properties.json
+++ b/.github/workflow-templates/bican-mccarroll-python-package.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "BICAN McCarroll python package Workflow",
+    "description": "Invoke the BICAN McCarroll reusable python package CI workflow.",
+    "categories": [
+        "Python",
+        "continuous-integration"
+    ]
+}

--- a/.github/workflow-templates/bican-mccarroll-python-package.yml
+++ b/.github/workflow-templates/bican-mccarroll-python-package.yml
@@ -1,0 +1,19 @@
+---
+name: "Python unit tests for a package"
+"on":
+  push:
+    branches:
+      - "$default-branch"
+  pull_request:
+    branches:
+      - "$default-branch"
+    paths:
+      - "python/bican_mccarroll_<package_name>/**"
+
+
+jobs:
+  call-python-reusable:
+    uses: "./.github/workflows/python-reusable.yml"
+    with:
+      package_name: "<package_name>"
+    secrets: "inherit"

--- a/.github/workflow-templates/bican-mccarroll-r-package.properties.json
+++ b/.github/workflow-templates/bican-mccarroll-r-package.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "BICAN McCarroll R package Workflow",
+    "description": "Invoke the BICAN McCarroll reusable R package CI workflow.",
+    "categories": [
+        "R",
+        "continuous-integration"
+    ]
+}

--- a/.github/workflow-templates/bican-mccarroll-r-package.yml
+++ b/.github/workflow-templates/bican-mccarroll-r-package.yml
@@ -1,0 +1,23 @@
+---
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures?
+# Start at https://github.com/r-lib/actions#where-to-find-help
+"on":
+  push:
+    branches:
+      - "$default-branch"
+  pull_request:
+    branches:
+      - "$default-branch"
+    paths:
+      - "R/bican.mccarroll.<package_name>/**"
+
+name: "Build and check R package"
+
+
+jobs:
+  call-R-reusable:
+    uses: "./.github/workflows/R-reusable.yml"
+    with:
+      package_name: "<package_name>"
+    secrets: "inherit"

--- a/.github/workflow-templates/bican-mccarroll-roxygen.properties.json
+++ b/.github/workflow-templates/bican-mccarroll-roxygen.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "BICAN McCarroll Roxygen package Workflow",
+    "description": "Invoke the BICAN McCarroll reusable R package documentation generation workflow.",
+    "categories": [
+        "R",
+        "continuous-integration"
+    ]
+}

--- a/.github/workflow-templates/bican-mccarroll-roxygen.yml
+++ b/.github/workflow-templates/bican-mccarroll-roxygen.yml
@@ -1,0 +1,23 @@
+---
+# Workflow derived from dplyr/.github/workflows/pr-commands.yaml
+# Need help debugging build failures?
+# Start at https://github.com/r-lib/actions#where-to-find-help
+"on":
+  issue_comment:
+    types:
+      - "created"
+    paths:
+      - "R/bican.mccarroll.<package_name>/**"
+
+name: >
+  Run roxygen2 on an R package and commit changes.
+  Triggered by a PR comment '/document.<package_name>'
+
+permissions: "write-all"
+
+jobs:
+  call-roxygen-reusable:
+    uses: "./.github/workflows/roxygen-reusable.yml"
+    with:
+      package_name: "<package_name>"
+    secrets: "inherit"

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,6 @@ patterns. To the extent possible, try to make your workflow generalizable:
 While we want to keep this repo manageable, we also want to give teams enough
 leeway to maintain their own tools without constantly getting in their way. When
 adding your workflow template, add both files to
-[CODEOWNERS](./.github/CODEOWNERS) along with your team. This way, after the
+[CODEOWNERS](https://github.com/broadinstitute/.github/blob/main/.github/CODEOWNERS) along with your team. This way, after the
 initial PR, teams can update and modify their own workflows without waiting on
 review from BITS. More details are available in the CODEOWNERS file.


### PR DESCRIPTION
Note that these workflow templates merely invoke resuable workflows in broadinstitute/bican-mccarroll-manuscript1/.github/workflow-templates, so they don't really follow the contribution guidelines, because they aren't reusable outside of broadinstitute/bican-mccarroll-manuscript1 repo.  However, if I could put the resuable workflows into broadinstitute/.github/.github/workflows, then I *could* make both the templates and the reusable workflows usable outside of our repo.

It's not critical that this PR be merged, I'm just hoping it will make it a little easier for my users to set up CI when they are contributing a package.