### PR TITLE
Aw bican mccarroll template instructions

### DIFF
--- a/workflow-templates/bican-mccarroll-python-package.yml
+++ b/workflow-templates/bican-mccarroll-python-package.yml
@@ -1,12 +1,17 @@
 ---
-name: "Python unit tests for a package"
+# Instructions for using this template:
+# 1. Replace <package_name> below with the short name of the python package.
+#    E.g. if the package is bican_mccarroll_mypackage, replace "<package_name>" with "mypackage".
+# 2. Name the workflow file python-<package_name>.yml, e.g. python-mypackage.yml
+# 3. Commit the above changes
+name: "Python unit tests for bican_mccarroll_<package_name>"
 "on":
   push:
     branches:
-      - "$default-branch"
+      - "main"
   pull_request:
     branches:
-      - "$default-branch"
+      - "main"
     paths:
       - "python/bican_mccarroll_<package_name>/**"
 

--- a/workflow-templates/bican-mccarroll-python-package.yml
+++ b/workflow-templates/bican-mccarroll-python-package.yml
@@ -1,17 +1,18 @@
 ---
 # Instructions for using this template:
 # 1. Replace <package_name> below with the short name of the python package.
-#    E.g. if the package is bican_mccarroll_mypackage, replace "<package_name>" with "mypackage".
+#    E.g. if the package is bican_mccarroll_mypackage, replace "<package_name>"
+#    with "mypackage".
 # 2. Name the workflow file python-<package_name>.yml, e.g. python-mypackage.yml
 # 3. Commit the above changes
 name: "Python unit tests for bican_mccarroll_<package_name>"
 "on":
   push:
     branches:
-      - "main"
+      - $default-branch  # yamllint disable-line rule:quoted-strings
   pull_request:
     branches:
-      - "main"
+      - $default-branch  # yamllint disable-line rule:quoted-strings
     paths:
       - "python/bican_mccarroll_<package_name>/**"
 

--- a/workflow-templates/bican-mccarroll-r-package.yml
+++ b/workflow-templates/bican-mccarroll-r-package.yml
@@ -1,18 +1,24 @@
 ---
+# Instructions for using this template:
+# 1. Replace <package_name> below with the short name of the python package.
+#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>" with "mypackage".
+# 2. Name the workflow file R-<package_name>.yml, e.g. R-mypackage.yml
+# 3. Commit the above changes
+
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures?
 # Start at https://github.com/r-lib/actions#where-to-find-help
 "on":
   push:
     branches:
-      - "$default-branch"
+      - "main"
   pull_request:
     branches:
-      - "$default-branch"
+      - "main"
     paths:
       - "R/bican.mccarroll.<package_name>/**"
 
-name: "Build and check R package"
+name: "Build and check R bican.mccarroll.<package_name> package"
 
 
 jobs:

--- a/workflow-templates/bican-mccarroll-r-package.yml
+++ b/workflow-templates/bican-mccarroll-r-package.yml
@@ -1,7 +1,8 @@
 ---
 # Instructions for using this template:
 # 1. Replace <package_name> below with the short name of the python package.
-#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>" with "mypackage".
+#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>"
+#    with "mypackage".
 # 2. Name the workflow file R-<package_name>.yml, e.g. R-mypackage.yml
 # 3. Commit the above changes
 
@@ -11,10 +12,10 @@
 "on":
   push:
     branches:
-      - "main"
+      - $default-branch  # yamllint disable-line rule:quoted-strings
   pull_request:
     branches:
-      - "main"
+      - $default-branch  # yamllint disable-line rule:quoted-strings
     paths:
       - "R/bican.mccarroll.<package_name>/**"
 

--- a/workflow-templates/bican-mccarroll-roxygen.yml
+++ b/workflow-templates/bican-mccarroll-roxygen.yml
@@ -1,8 +1,10 @@
 ---
 # Instructions for using this template:
 # 1. Replace <package_name> below with the short name of the python package.
-#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>" with "mypackage".
-# 2. Name the workflow file roxygen-<package_name>.yml, e.g. roxygen-mypackage.yml
+#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>"
+#    with "mypackage".
+# 2. Name the workflow file roxygen-<package_name>.yml, e.g.
+#    roxygen-mypackage.yml
 # 3. Commit the above changes
 
 # Workflow derived from dplyr/.github/workflows/pr-commands.yaml

--- a/workflow-templates/bican-mccarroll-roxygen.yml
+++ b/workflow-templates/bican-mccarroll-roxygen.yml
@@ -1,4 +1,10 @@
 ---
+# Instructions for using this template:
+# 1. Replace <package_name> below with the short name of the python package.
+#    E.g. if the package is bican.mccarroll.mypackage, replace "<package_name>" with "mypackage".
+# 2. Name the workflow file roxygen-<package_name>.yml, e.g. roxygen-mypackage.yml
+# 3. Commit the above changes
+
 # Workflow derived from dplyr/.github/workflows/pr-commands.yaml
 # Need help debugging build failures?
 # Start at https://github.com/r-lib/actions#where-to-find-help
@@ -10,7 +16,7 @@
       - "R/bican.mccarroll.<package_name>/**"
 
 name: >
-  Run roxygen2 on an R package and commit changes.
+  Run roxygen2 on R package bican.mccarroll..<package_name> and commit changes.
   Triggered by a PR comment '/document.<package_name>'
 
 permissions: "write-all"


### PR DESCRIPTION
- Added instructions for template use.
- Hacked around problem with `$default-branch`.  Note that yamllint requires `"$default-branch"`, but when the template is used, that is translated into `""main""`.

I forget if I said this before, but if these are deemed generally useful, I could remove the bican_mccarroll specificity.